### PR TITLE
Фикс No module named 'config'

### DIFF
--- a/infra/prod/docker-compose.prod.yaml
+++ b/infra/prod/docker-compose.prod.yaml
@@ -30,8 +30,6 @@ services:
       sh -c  "export DJANGO_SETTINGS_MODULE=config.settings &&
               daphne config.asgi:application -b 0.0.0.0 -p 8001 --access-log -"
     restart: always
-    volumes:
-      - .:/app/
     expose:
       - 8001
     depends_on:


### PR DESCRIPTION
Фикс ошибки `ModuleNotFoundError: No module named 'config'` при старте docker compose prod.

Причина ошибки: забыл убрать настройку volumes из asgiserver в docker compose файле - она создавала volume с именем `app`, которое конфликтовало с именем app в докерфайле, в результате чего контейнер с ASGI сервером создавался с пустой папкой app и не мог найти свои файлы.