### PR TITLE
Тесты на регистрацию и аутентификацию пользователя

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,8 @@
 pythonpath = src/
 DJANGO_SETTINGS_MODULE = config.settings
 norecursedirs = venv/*
-addopts = -vv -p no:cacheprovider --disable-warnings
+addopts = -vv -p no:cacheprovider
 testpaths = tests/
 python_files = test_*.py
+filterwarnings =
+    ignore::DeprecationWarning

--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -1,3 +1,8 @@
+from django.contrib.auth import password_validation as pv
+from django.core.exceptions import ValidationError
+from django.db.models.fields import Field as DjangoField
+from djoser.constants import Messages as DjoserMessages
+
 MIN_LENGTH_EMAIL = 5
 MAX_LENGTH_EMAIL = 254
 MIN_LENGTH_CHAR = 2
@@ -57,6 +62,28 @@ class Messages(object):
     USER_IS_NOT_FRIEND = (
         "Чтобы начать чат, вы должны быть в друзьях с пользователем %s."
     )
+
+    # Ниже получаем стандартные сообщения валидации Django и других пакетов
+    FIELD_CANNOT_BE_BLANK_MSG = DjangoField.default_error_messages["blank"]
+    INVALID_CREDENTIALS_MSG = DjoserMessages.INVALID_CREDENTIALS_ERROR
+
+    def _get_standard_message(self, validation_method, value):
+        try:
+            validation_method(value)
+        except ValidationError as e:
+            return e.message
+
+    @property
+    def password_numeric_msg(self):
+        """Сообщение Django при попытке использовать пароль только из цифр."""
+        obj = pv.NumericPasswordValidator()
+        return self._get_standard_message(obj.validate, "81672049")
+
+    @property
+    def password_common_msg(self):
+        """Сообщение Django при попытке ввести распространённый пароль."""
+        obj = pv.CommonPasswordValidator()
+        return self._get_standard_message(obj.validate, "qwerty123")
 
 
 messages = Messages()

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -51,6 +51,7 @@ pycparser==2.21
 PyJWT==2.8.0
 pyOpenSSL==24.1.0
 pytest==8.1.1
+pytest-django==4.8.0
 python-dotenv==1.0.1
 python3-openid==3.2.0
 pytz==2024.1

--- a/tests/fixtures/fixture_user.py
+++ b/tests/fixtures/fixture_user.py
@@ -5,19 +5,38 @@ import pytest
 def user(django_user_model):
     """Тестовые данные для пользователя 1."""
     return django_user_model.objects.create_user(
-        first_name="TestUser1",
-        last_name="TestUser",
-        password="1234567",
-        email="test@tesr.ru",
+        first_name="Тестовый",
+        last_name="Юзер",
+        password="alskdj01",
+        email="testone@test.ru",
     )
 
 
 @pytest.fixture
-def user_2(django_user_model):
+def another_user(django_user_model):
     """Тестовые данные для пользователя 2."""
     return django_user_model.objects.create_user(
-        first_name="TestUser2",
-        last_name="TestUser",
-        password="1234567",
-        email="test@tesr.ru",
+        first_name="Второй",
+        last_name="Юзер",
+        password="alskdj02",
+        email="testtwo@test.ru",
     )
+
+
+@pytest.fixture
+def token(user):
+    """Создание токена для пользователя."""
+    from rest_framework.authtoken.models import Token
+
+    token, _ = Token.objects.get_or_create(user=user)
+    return token.key
+
+
+@pytest.fixture
+def user_client(token):
+    """Создание клиента для аутентифицированного пользователя."""
+    from rest_framework.test import APIClient
+
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    return client

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -181,8 +181,17 @@ class TestAuthAPI:
             f"{HTTPStatus.UNAUTHORIZED}, а не {users_me_response.status_code}."
         )
 
-    def test_auth_authorized_user(self, client):
-        """Проверка доступа к ресурсам, требующим аутентификации."""
+    def test_auth_authenticated_user(self, user_client):
+        """У аутентифицированного пользователя должен быть доступ."""
+        users_me_response = user_client.get(self.user_profile_url)
+        assert users_me_response.status_code == HTTPStatus.OK, (
+            "При обращении аутентифицированного пользователя к ресурсу "
+            f"`{self.user_profile_url}` должен возвращаться статус "
+            f"{HTTPStatus.OK}, а вернулся {users_me_response.status_code}."
+        )
+
+    def test_auth_unauthenticated_user(self, client):
+        """У анонимного пользователя не должно быть доступа."""
         users_me_response = client.get(self.user_profile_url)
         assert users_me_response.status_code == HTTPStatus.OK, (
             "При обращении аутентифицированного пользователя к ресурсу "

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,196 @@
+import random
+import string
+
+import pytest
+
+
+def generate_long_email(length):
+    """Генерация слишком длинного адреса электронной почты."""
+    local_part = "".join(
+        random.choices(string.ascii_letters + string.digits, k=length - 15)
+    )
+    domain = "".join(random.choices(string.ascii_lowercase, k=250))
+    return local_part + "@" + domain + ".com"
+
+
+def generate_long_password(length):
+    """Генерация слишком длинного пароля."""
+    return "".join(
+        random.choices(string.ascii_letters + string.digits, k=length)
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+class TestAuthAPI:
+    """Тесты аутентификации."""
+
+    login_url = "/api/v1/auth/token/login/"
+    logout_url = "/api/v1/auth/token/logout/"
+
+    def test_auth_correct_data(self, client, user):
+        """Проверка успешного входа в систему при вводе корректных данных."""
+        response = client.post(
+            self.login_url,
+            data={"email": user.email, "password": "alskdj01"},
+        )
+
+        assert response.status_code != 404, (
+            f"Страница `{self.login_url}` не найдена, проверьте этот адрес "
+            "в *urls.py*"
+        )
+
+        assert (
+            response.status_code == 200
+        ), f"Страница `{self.login_url}` работает неправильно!"
+
+        auth_data = response.json()
+        assert "auth_token" in auth_data, (
+            f"Проверьте, что при POST запросе `{self.login_url}` "
+            "возвращаете токен"
+        )
+
+    @pytest.mark.parametrize(
+        "email,error_text,status_code",
+        [
+            (
+                "русскиесимволы@test.ru",
+                "Почта должна содержать буквы только английского алфавита.",
+                400,
+            ),
+            ("invalidemail.ru", "Некорректный адрес электронной почты.", 400),
+            ("a@a", "Почта должна содержать от 5 до 254 символов.", 400),
+            (
+                generate_long_email(260),
+                "Почта должна содержать от 5 до 254 символов.",
+                400,
+            ),
+            (
+                "wrong<>symbols@test.ru",
+                "Некорректный адрес электронной почты.",
+                400,
+            ),
+        ],
+        ids=[
+            "rus_symbols",
+            "invalid_format",
+            "too_short",
+            "too_long",
+            "wrong_symbols",
+        ],
+    )
+    def test_auth_invalid_email(self, client, email, error_text, status_code):
+        """Проверка ввода электронной почты в некорректном формате."""
+        response = client.post(
+            self.login_url,
+            data={"email": email, "password": "rndmpsswd"},
+        )
+        assert error_text == response.json()["non_field_errors"][0], (
+            f"При передаче {email} на `{self.login_url}` "
+            f"должен возвращаться текст ошибки `{error_text}`, "
+            f"а вернулся `{response.json()['non_field_errors'][0]}`."
+        )
+
+        assert response.status_code == status_code, (
+            f"При передаче {email} на `{self.login_url}` "
+            f"должен возвращаться статус {status_code}, "
+            f"а был возвращен {response.status_code}."
+        )
+
+    @pytest.mark.parametrize(
+        "password,error_text,status_code",
+        [
+            ("short", "Пароль должен содержать от 8 до 50 символов.", 400),
+            (
+                generate_long_password(51),
+                "Пароль должен содержать от 8 до 50 символов.",
+                400,
+            ),
+        ],
+        ids=[
+            "too_short",
+            "too_long",
+        ],
+    )
+    def test_auth_invalid_password(
+        self, client, password, error_text, status_code
+    ):
+        """Проверка ввода пароля в некорректном формате."""
+        response = client.post(
+            self.login_url,
+            data={"email": "a@a.ru", "password": password},
+        )
+        assert error_text == response.json()["non_field_errors"][0], (
+            f"При передаче {password} на `{self.login_url}` "
+            f"должен возвращаться текст ошибки `{error_text}`, "
+            f"а вернулся `{response.json()['non_field_errors'][0]}`."
+        )
+
+        assert response.status_code == status_code, (
+            f"При передаче {password} на `{self.login_url}` "
+            f"должен возвращаться статус {status_code}, "
+            f"а был возвращен {response.status_code}."
+        )
+
+    @pytest.mark.parametrize(
+        "email,password",
+        [(" ", "validpasswd"), ("validemail@test.ru", " ")],
+        ids=["empty_email", "empty_password"],
+    )
+    def test_auth_empty_fields(self, client, email, password):
+        """Проверка ввода пустых полей."""
+        response = client.post(
+            self.login_url,
+            data={"email": email, "password": password},
+        )
+        assert response.status_code == 400, (
+            f"При передаче пустых полей на `{self.login_url}` "
+            f"должен возвращаться статус 400, а не {response.status_code}."
+        )
+        assert [
+            "Это поле не может быть пустым."
+        ] in response.json().values(), (
+            f"При передаче пустых полей на `{self.login_url}` "
+            "должен возвращаться текст ошибки "
+            "`Это поле не может быть пустым.`"
+        )
+
+    @pytest.mark.parametrize(
+        "email,password",
+        [
+            ("nonexistentemail@test.ru", "alskdj01"),
+            ("testone@test.ru", "wrongpasswd"),
+        ],
+        ids=["nonexistent_email", "wrong_password"],
+    )
+    def test_auth_incorrect_data(self, client, user, email, password):
+        """Проверка ввода несуществующего email или неверного пароля."""
+        response = client.post(
+            self.login_url,
+            data={"email": email, "password": password},
+        )
+        assert response.status_code == 400, (
+            f"При передаче неверных данных на `{self.login_url}` "
+            f"должен возвращаться статус 400, а не {response.status_code}."
+        )
+        assert [
+            "Невозможно войти с предоставленными учетными данными."
+        ] in response.json().values(), (
+            f"При передаче неверных данных на `{self.login_url}` "
+            "должен возвращаться текст ошибки `Невозможно войти с "
+            "предоставленными учетными данными.`"
+        )
+
+    def test_auth_logout(self, user_client):
+        """Проверка выхода из аккаунта."""
+        response = user_client.post(self.logout_url)
+        assert response.status_code == 204, (
+            f"При передаче неверных данных на `{self.login_url}` "
+            f"должен возвращаться статус 204, а не {response.status_code}."
+        )
+
+        users_me_response = user_client.get("/api/v1/users/me/")
+        assert users_me_response.status_code == 401, (
+            "При выходе из аккаунта при попытке доступа к ресурсам, "
+            "требующим аутентификации, должен возвращаться статус 401, "
+            f"а не {users_me_response.status_code}."
+        )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -193,8 +193,9 @@ class TestAuthAPI:
     def test_auth_unauthenticated_user(self, client):
         """У анонимного пользователя не должно быть доступа."""
         users_me_response = client.get(self.user_profile_url)
-        assert users_me_response.status_code == HTTPStatus.OK, (
-            "При обращении аутентифицированного пользователя к ресурсу "
+        assert users_me_response.status_code == HTTPStatus.UNAUTHORIZED, (
+            "При обращении неаутентифицированного пользователя к ресурсу "
             f"`{self.user_profile_url}` должен возвращаться статус "
-            f"{HTTPStatus.OK}, а вернулся {users_me_response.status_code}."
+            f"{HTTPStatus.UNAUTHORIZED}, а вернулся "
+            f"{users_me_response.status_code}."
         )

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,190 @@
+from http import HTTPStatus
+
+import pytest
+
+from config import constants as cnst
+from config.constants import messages as msg
+
+from .test_auth import generate_long_email, generate_long_string
+
+
+@pytest.mark.django_db(transaction=True)
+class TestUserRegisterAPI:
+    """Тесты регистрации пользователей."""
+
+    users_url = "/api/v1/users/"
+
+    data = {
+        "first_name": "Новый",
+        "last_name": "Юзер",
+        "password": "validpasswd",
+        "email": "validemail@test.ru",
+    }
+
+    def test_register_correct_data(self, client):
+        """Проверка успешной регистрации при вводе корректных данных."""
+        response = client.post(self.users_url, self.data)
+
+        assert response.status_code != HTTPStatus.NOT_FOUND, (
+            f"Страница `{self.users_url}` не найдена, проверьте этот адрес "
+            "в *urls.py*"
+        )
+
+        assert (
+            response.status_code == HTTPStatus.CREATED
+        ), f"Страница `{self.users_url}` работает неправильно!"
+
+        register_data = response.json()
+        assert all(
+            field in register_data
+            for field in ["first_name", "last_name", "email"]
+        ), (
+            f"Проверьте, что при POST запросе на `{self.users_url}` "
+            "возвращается объект пользователя."
+        )
+
+    def test_register_existing_user(self, client, user):
+        """Проверка регистрации существующего пользователя."""
+        data = self.data.copy()
+        data["email"] = user.email
+        response = client.post(self.users_url, data)
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST, (
+            f"Проверьте, что при POST запросе на `{self.users_url}` "
+            "при попытке регистрации существующего пользователя "
+            f"возвращается статус {HTTPStatus.BAD_REQUEST}."
+        )
+
+    @pytest.mark.parametrize(
+        "email,error_text",
+        [
+            ("invalidemail.ru", msg.INVALID_EMAIL_MSG),
+            (
+                generate_long_email(cnst.MAX_LENGTH_EMAIL + 1),
+                msg.EMAIL_LENGTH_MSG,
+            ),
+            ("wrong<>symbols@test.ru", msg.INVALID_EMAIL_MSG),
+        ],
+        ids=["invalid_format", "too_long", "wrong_symbols"],
+    )
+    def test_register_invalid_email(self, client, email, error_text):
+        """Проверка регистрации с электронной почтой в некорректном формате."""
+        data = self.data.copy()
+        data["email"] = email
+        response = client.post(self.users_url, data)
+        assert error_text == response.json()["email"][0], (
+            f"При регистрации с почтой {email} "
+            f"должен возвращаться текст ошибки `{error_text}`, "
+            f"а вернулся `{response.json()['email'][0]}`."
+        )
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST, (
+            f"При регистрации с почтой {email} "
+            f"должен возвращаться статус {HTTPStatus.BAD_REQUEST}, "
+            f"а был возвращен {response.status_code}."
+        )
+
+    @pytest.mark.parametrize(
+        "password,error_text",
+        [
+            ("p", msg.PASSWORD_LENGTH_MSG),
+            (
+                generate_long_string(cnst.MAX_LENGTH_PASSWORD + 1),
+                msg.PASSWORD_LENGTH_MSG,
+            ),
+            ("81672049", msg.password_numeric_msg),
+            ("qwerty123", msg.password_common_msg),
+        ],
+        ids=[
+            "too_short",
+            "too_long",
+            "only_digits",
+            "too_common",
+        ],
+    )
+    def test_resgiter_invalid_password(self, client, password, error_text):
+        """Проверка регистрации с паролем в некорректном формате."""
+        data = self.data.copy()
+        data["password"] = password
+        response = client.post(self.users_url, data)
+        assert error_text == response.json()["password"][0], (
+            f"При передаче {password} на `{self.users_url}` "
+            f"должен возвращаться текст ошибки `{error_text}`, "
+            f"а вернулся `{response.json()['password'][0]}`."
+        )
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST, (
+            f"При передаче {password} на `{self.users_url}` "
+            f"должен возвращаться статус {HTTPStatus.BAD_REQUEST}, "
+            f"а был возвращен {response.status_code}."
+        )
+
+    @pytest.mark.parametrize(
+        "field,value,error_text",
+        [
+            ("first_name", "F", msg.FIRST_NAME_LENGTH_MSG),
+            ("last_name", "L", msg.LAST_NAME_LENGTH_MSG),
+            (
+                "first_name",
+                generate_long_string(cnst.MAX_LENGTH_CHAR + 1),
+                msg.FIRST_NAME_LENGTH_MSG,
+            ),
+            (
+                "last_name",
+                generate_long_string(cnst.MAX_LENGTH_CHAR + 1),
+                msg.LAST_NAME_LENGTH_MSG,
+            ),
+            ("first_name", "123", msg.INVALID_SYMBOLS_MSG),
+            ("last_name", "<>", msg.INVALID_SYMBOLS_MSG),
+        ],
+        ids=[
+            "short_first_name",
+            "short_last_name",
+            "long_first_name",
+            "long_last_name",
+            "invalid_symbols_first_name",
+            "invalid_symbols_last_name",
+        ],
+    )
+    def test_register_name(self, client, field, value, error_text):
+        """Проверка регистрации с некорректными именем и фамилией."""
+        data = self.data.copy()
+        data[field] = value
+        response = client.post(self.users_url, data)
+        assert error_text == response.json()[field][0], (
+            f"При передаче {value} в качестве значения поля {field} на "
+            f"`{self.users_url}` должен возвращаться текст ошибки "
+            f"{error_text}`, а вернулся `{response.json()[field][0]}`."
+        )
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST, (
+            f"При передаче {value} в качестве значения поля {field} на "
+            f"`{self.users_url}` должен возвращаться статус "
+            f"{HTTPStatus.BAD_REQUEST}, а вернулся {response.status_code}."
+        )
+
+    @pytest.mark.parametrize(
+        "field",
+        ["email", "password", "first_name", "last_name"],
+        ids=[
+            "empty_email",
+            "empty_password",
+            "empty_first_name",
+            "empty_last_name",
+        ],
+    )
+    def test_register_empty_fields(self, client, field):
+        """Проверка регистрации с пустыми полями."""
+        data = self.data.copy()
+        data[field] = " "
+        response = client.post(self.users_url, data)
+        assert response.status_code == HTTPStatus.BAD_REQUEST, (
+            f"При передаче пустых полей на `{self.users_url}` "
+            f"должен возвращаться статус {HTTPStatus.BAD_REQUEST}, а не "
+            f"{response.status_code}."
+        )
+        assert [msg.FIELD_CANNOT_BE_BLANK_MSG] in response.json().values(), (
+            f"При передаче пустых полей на `{self.users_url}` "
+            "должен возвращаться текст ошибки "
+            f"`{msg.FIELD_CANNOT_BE_BLANK_MSG}`."
+        )


### PR DESCRIPTION
Задача https://github.com/find-frend/find_friend_backend/issues/150

Один тест на проверку отсутствия доступа у неаутентифицированного пользователя падает: вместо 401 сервер падает с 500. Это поведение зашито в djoser - наш UserViewSet унаследован от джозеровского. Нужно делать фикс.